### PR TITLE
Add support for stderr

### DIFF
--- a/examples/stderr/main.rs
+++ b/examples/stderr/main.rs
@@ -1,0 +1,17 @@
+/// Run
+/// ```
+/// cargo run --example stderr 2> error.log
+/// ```
+/// then the `error.log` file should contain `ERROR: unexpected` with some gibberish 
+
+use prettyprint::{PrettyPrinter, PagingMode, PrettyPrintError};
+
+fn main() -> Result<(), PrettyPrintError> {
+
+    let epprint = PrettyPrinter::default()
+        .paging_mode(PagingMode::Error)
+        // Comment ☝️ to make `error.log` empty
+        .build().unwrap();
+
+    epprint.string("ERROR: unexpected")
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -24,6 +24,7 @@ pub enum PagingMode {
     Always,
     QuitIfOneScreen,
     Never,
+    Error,
 }
 
 impl Default for PagingMode {

--- a/src/output.rs
+++ b/src/output.rs
@@ -12,6 +12,7 @@ use crate::errors::*;
 pub enum OutputType {
     Pager(Child),
     Stdout(io::Stdout),
+    Stderr(io::Stderr),
 }
 
 impl OutputType {
@@ -20,7 +21,8 @@ impl OutputType {
         Ok(match mode {
             Always => OutputType::try_pager(false, pager)?,
             QuitIfOneScreen => OutputType::try_pager(true, pager)?,
-            _ => OutputType::stdout(),
+            Never => OutputType::stdout(),
+            Error => OutputType::stderr(),
         })
     }
 
@@ -76,6 +78,10 @@ impl OutputType {
         OutputType::Stdout(io::stdout())
     }
 
+    fn stderr() -> Self {
+        OutputType::Stderr(io::stderr())
+    }
+
     pub fn handle(&mut self) -> Result<&mut Write> {
         Ok(match *self {
             OutputType::Pager(ref mut command) => command
@@ -83,6 +89,7 @@ impl OutputType {
                 .as_mut()
                 .chain_err(|| "Could not open stdin for pager")?,
             OutputType::Stdout(ref mut handle) => handle,
+            OutputType::Stderr(ref mut handle) => handle,
         })
     }
 }


### PR DESCRIPTION
> fix #8

Usage:
```rust
use prettyprint::*;

let pring = PrettyPrinter::default()
    .paging_mode(PagingMode::Error)
    .build()?;
```