### PR TITLE
Load custom syntaxes.bin or themes.bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Highlighting Assets
+**/*.bin
+
+# Rust
 /target
 **/*.rs.bk
 Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ matrix:
   fast_finish: true
 script:
   - cargo build --verbose
-  - cargo test --verbose
+  - cargo test --verbose --lib

--- a/assets/syntaxes/Pikalang.sublime-syntax
+++ b/assets/syntaxes/Pikalang.sublime-syntax
@@ -1,0 +1,27 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+name: Pikalang
+file_extensions: [pokeball] # https://github.com/groteworld/pikalang#file-extention
+scope: source.pikalang
+contexts:
+  main: # https://github.com/groteworld/pikalang#syntax
+    - match: \spi\s
+      scope: markup.underline.pikalang
+    - match: \ska\s
+      scope: markup.underline.pikalang
+    - match: \spika\s
+      scope: keyword.control.name
+    - match: \schu\s
+      scope: keyword.control.name
+    - match: \spipi\s
+      scope: keyword.operator.pikalang
+    - match: \spichu\s
+      scope: keyword.operator.pikalang
+    - match: \spikapi\s
+      scope: support.function.name
+    - match: \spikachu\s
+      scope: support.function.name
+    - match: "#.*$"
+      scope: comment.pikalang
+

--- a/examples/load-asset.rs
+++ b/examples/load-asset.rs
@@ -49,11 +49,11 @@ fn main() -> Result<(), PrettyPrintError> {
         }
         Some("theme") => {
             let print = PrettyPrinter::default()
-                .language(LANGUAGE)
+                .language("rust")
                 .load_theme(buffer.to_vec())
                 .build()?;
 
-            print.string(CODE)?;
+            print.string(include_str!("../fixtures/fib.rs"))?;
         }
         _ => help(),
     }

--- a/examples/load-asset.rs
+++ b/examples/load-asset.rs
@@ -1,0 +1,62 @@
+//! Create highlighting assets using bat
+//! ```
+//! bat cache --build --blank --source ./assets --target ./assets/pokemon
+//! ```
+//! compile by defining ASSET environment variable
+//! ```
+//! ASSET=../assets/pokemon/syntaxes.bin cargo build --example load-asset
+//! ```
+//! then run
+//! ```
+//! cargo run --example load-asset -- syntax
+//! ```
+
+use prettyprint::{PrettyPrintError, PrettyPrinter};
+use std::{env, process};
+
+const LANGUAGE: &str = "pikalang"; // https://github.com/groteworld/pikalang
+const CODE: &str = "
+pi pi pi pi pi pi pi pi pi pi pika pipi pi pi pi pi pi pi pi pipi pi pi pi
+pi pi pi pi pi pi pi pipi pi pi pi pipi pi pichu pichu pichu pichu ka chu
+pipi pi pi pikachu pipi pi pikachu pi pi pi pi pi pi pi pikachu pikachu pi
+pi pi pikachu pipi pi pi pikachu pichu pichu pi pi pi pi pi pi pi pi pi pi
+pi pi pi pi pi pikachu pipi pikachu pi pi pi pikachu ka ka ka ka ka ka
+pikachu ka ka ka ka ka ka ka ka pikachu pipi pi pikachu pipi pikachu";
+
+fn help() -> ! {
+    println!(
+        "USAGE: \
+         \tASSET=../assets/syntaxes.bin {load} syntax\n \
+         \tASSET=../assets/themes.bin {load} theme",
+        load = "cargo run --example load-asset -- "
+    );
+    process::exit(2);
+}
+
+fn main() -> Result<(), PrettyPrintError> {
+    let mut env = env::args().skip(1);
+
+    let buffer = include_bytes!(env!("ASSET"));
+
+    match env.next().as_ref().map(<_>::as_ref) {
+        Some("syntax") => {
+            let print = PrettyPrinter::default()
+                .language(LANGUAGE)
+                .load_syntax(buffer.to_vec())
+                .build()?;
+
+            print.string(CODE)?;
+        }
+        Some("theme") => {
+            let print = PrettyPrinter::default()
+                .language(LANGUAGE)
+                .load_theme(buffer.to_vec())
+                .build()?;
+
+            print.string(CODE)?;
+        }
+        _ => help(),
+    }
+
+    Ok(())
+}

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -49,11 +49,11 @@ impl HighlightingAssets {
         })
     }
 
-    fn get_integrated_syntaxset() -> SyntaxSet {
+    pub(crate) fn get_integrated_syntaxset() -> SyntaxSet {
         from_binary(include_bytes!("../assets/syntaxes.bin"))
     }
 
-    fn get_integrated_themeset() -> ThemeSet {
+    pub(crate) fn get_integrated_themeset() -> ThemeSet {
         from_binary(include_bytes!("../assets/themes.bin"))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,30 @@ mod tests {
         printer.file("fixtures/fib.rs").unwrap();
     }
 
+    #[test]
+    fn it_can_load_syntaxset() {
+        let buffer: Vec<u8> = include_bytes!("../assets/syntaxes.bin").to_vec();
+        let printer = PrettyPrinter::default()
+            .language("rust")
+            .load_syntax(buffer)
+            .build()
+            .unwrap();
+
+        printer.file("fixtures/fib.rs").unwrap();
+    }
+
+    #[test]
+    fn it_can_load_themeset() {
+        let buffer = include_bytes!("../assets/themes.bin").to_vec();
+        let printer = PrettyPrinter::default()
+            .language("rust")
+            .load_theme(buffer)
+            .build()
+            .unwrap();
+
+        printer.file("fixtures/fib.rs").unwrap();
+    }
+
     /// Show available syntax highlighting themes
     #[test]
     fn show_themes() {


### PR DESCRIPTION
I happen need this capability for my personal project 🥺

```rust
let print = PrettyPrinter::default().language("mylang")
    .load_syntax(include_bytes!("./syntaxset_that_include_mylang.bin").to_vec())
    .build()?;

print.string(CODE)?;
```